### PR TITLE
Add devcontainer for easy development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bullseye
+
+ADD requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    # install project dependcies
+    && pip install --no-cache-dir --requirement /tmp/requirements.txt
+
+# Clean up
+RUN rm -f /tmp/requirements.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,78 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "aau-vms-devcontainer",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	"build": {
+		"context": "..",
+		"dockerfile": "Dockerfile"
+	},
+	"runArgs": [
+		// remove containers when the related tool window is closed/shutdown
+		"--rm"
+	],
+	"remoteEnv": {
+		// enable bound mounts from workspace folder for docker-outside-of-docker
+		// https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker
+		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
+		"CONTAINER_WORKSPACE_FOLDER": "${containerWorkspaceFolder}"
+	},
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers-community/npm-features/prettier:1": {
+			// plugins should be separated by space, not commas
+			"plugins": "prettier-plugin-sh prettier-plugin-sql prettier-plugin-jinja-template"
+		},
+		"ghcr.io/gvatsal60/dev-container-features/pre-commit:1": {}
+	},
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			// Configure properties specific to VS Code
+			"extensions": [
+				"timonwong.shellcheck",
+				"foxundermoon.shell-format",
+				"ms-python.black-formatter",
+				"ms-azuretools.vscode-docker",
+				"bysabi.prettier-vscode-standard",
+				"streetsidesoftware.code-spell-checker"
+			],
+			"settings": {
+				"editor.formatOnSave": true,
+				"debugpy.showPythonInlineValues": true,
+				"editor.formatOnSaveMode": "modificationsIfAvailable",
+				"editor.defaultFormatter": "bysabi.prettier-vscode-standard",
+				"[jsonc]": {
+					"editor.defaultFormatter": "vscode.json-language-features"
+				},
+				"[python]": {
+					"analysis.importFormat": "absolute",
+					"analysis.autoImportCompletions": true,
+					"analysis.inlayHints.callArgumentNames": "partial",
+					"editor.defaultFormatter": "ms-python.black-formatter",
+					"editor.codeActionsOnSave": {
+						"source.organizeImports": "always",
+						"source.unusedImports": "always"
+					}
+				},
+				"[shellscript]": {
+					"editor.defaultFormatter": "foxundermoon.shell-format"
+				},
+				"[dockercompose]": {
+					"editor.defaultFormatter": "ms-azuretools.vscode-docker"
+				},
+				"[dockerfile]": {
+					"editor.defaultFormatter": "ms-azuretools.vscode-docker"
+				}
+			}
+		}
+	},
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "chmod +x ./.devcontainer/postCreateCommand.sh && ./.devcontainer/postCreateCommand.sh"
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Avoid dubious ownership in dev container:
+# https://www.kenmuse.com/blog/avoiding-dubious-ownership-in-dev-containers/
+git config --global --add safe.directory "$CONTAINER_WORKSPACE_FOLDER"
+
+# install pre-commit hooks
+pre-commit install
+
+# Build application image & start the stack
+make init

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Created by https://www.toptal.com/developers/gitignore/api/python,windows,macos,linux,django,node,react
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,windows,macos,linux,django,node,react
 
+### ignore folder - helpful for files you don't want to delete or add to ignore file###
+IGNORE/
+
 ### Django ###
 *.log
 *.pot

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+fail_fast: true
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+      - id: check-json
+        exclude: '^\.devcontainer/devcontainer\.json$'
+      - id: end-of-file-fixer
+        exclude: '^\.devcontainer/devcontainer\.json$'
+      - id: detect-private-key
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: no-commit-to-branch

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.devcontainer/devcontainer.json
+IGNORE/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update -y
 # Add requirements file. This will be used to install
 ADD requirements.txt /tmp
 # Update pip & any requirements
-RUN pip install -U pip \
-    && pip install -r /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir --requirement /tmp/requirements.txt
 
 # Clean up
 RUN rm /tmp/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,52 +1,102 @@
 # Angel Among Us Volunteer Management System
 
-## Getting Started
+# Getting Started
+
 **Instructions and setup below are for development and should not be used if deploying
 to production. See the [deployment instructions](#deployment) below for that**.
 
-### Perquisites
+## Perquisites
+
 To get the project up and running, you'll need:
 
-* [Docker](https://www.docker.com)
+- [Docker](https://www.docker.com)
 
-    * If installing on Windows, you may need to install/enable [WSL-2](https://learn.microsoft.com/en-us/windows/wsl/install) first.
+  - If installing on Windows, you may need to install/enable [WSL-2](https://learn.microsoft.com/en-us/windows/wsl/install) first.
 
-* You IDE of choice
-* Some familiarity with terminal/command prompt
+- You IDE of choice
+- Some familiarity with terminal/command prompt
 
-    * If using Windows, it's recommended to install & use [Windows Terminal](https://learn.microsoft.com/en-us/windows/terminal/install).
-* If on Windows, [show/enable hidden files](https://support.microsoft.com/en-us/windows/view-hidden-files-and-folders-in-windows-97fbc472-c603-9d90-91d0-1166d1d9f4b5)
+  - If using Windows, it's recommended to install & use [Windows Terminal](https://learn.microsoft.com/en-us/windows/terminal/install).
+
+- If on Windows, [show/enable hidden files](https://support.microsoft.com/en-us/windows/view-hidden-files-and-folders-in-windows-97fbc472-c603-9d90-91d0-1166d1d9f4b5)
 
 This is a fully containerized stack, as such there's no need to install anything locally. The project is shared (mounted) to the container
 and changes are synced both ways.
 
-### Running It
+## Running It
+
+### Environment file
+
+First things first is to create your environment file. This file defines
+environment variables that are accessible from any process.
 
 1. In the project folder make a copy of `example.env` and name it `.env` (note the dot in the file name)
 2. Edit `.env` by filling in the required settings
 
-**A [makefile](#makefile) is included with this project to streamline
-repetitive tasks. You can use it instead running commands directly.**
+From here, you have a couple of options of development environment:
+
+- [Dev container](#dev-container) - simple & easy
+- [Local](#local) - your milage may vary
+
+### Dev Container
+
+A [dev container](https://containers.dev) is included with this project to
+streamline and simplify collaborative development. This is a docker container
+with all application dependencies and tools. This is the preferred and
+recommended way to develop on this project.
+
+While dev containers are supported by a number of [different tools and services](https://containers.dev/supporting) this particular configuration (described in [.devcontainer.json](.devcontainer/devcontainer.json)) is tailored towards [Visual Studio Code](https://code.visualstudio.com).
+
+1. Open VS Code
+2. If not installed, install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+3. Open the project in VS Code.
+
+   Once the project is loaded you should get a
+   prompt in the bottom-right corner to **"Reopen in Container"**. Click it to
+   reopen the project in the dev container.
+
+4. If you did not receive the **"Reopen in Container"** prompt:
+
+   1. Open VS Code Command Palette
+   2. Type in `Dev Containers` and select **"Reopen in Container"**
+
+### Local
+
+To develop locally, you'll need to install Python & add it to your system PATH.
+
+Additionally, instead of installing Python packages system wide it's best to use
+a [Python virtual environment](https://realpython.com/python-virtual-environments-a-primer/#how-can-you-work-with-a-python-virtual-environment).
+
+A [makefile](#makefile) is included with this project to streamline repetitive
+tasks. You can use it instead running commands directly.
 
 Assuming Docker is running:
 
 1. Open a terminal/command prompt
 2. In the terminal, navigate to the project folder
 
-    ```shell
-    # if on Windows the path separator would be \ instead of /
-    cd /path/to/angels-among-us-vms
-    ```
-3. Build the project's docker image:
+   ```shell
+   # if on Windows the path separator would be \ instead of /
+   cd /path/to/angels-among-us-vms
+   ```
 
-    ```shell
-    docker build -t aau-vms .
-    ```
-4. Bring up the application stack
+3. Install project dependencies
 
-    ```shell
-    docker compose up -d
-    ```
+   ```shell
+   pip install -r requirements.txt
+   ```
+
+4. Build the project's docker image:
+
+   ```shell
+   docker build -t aau-vms .
+   ```
+
+5. Bring up the application stack
+
+   ```shell
+   docker compose up -d
+   ```
 
 If there are no issues, this will build and pull all the necessary images. Once
 it is complete, check Docker Desktop. All services under `vms` should be green (running).
@@ -55,8 +105,9 @@ In your browser visit [http://localhost/app](http://localhost/app) and ta-da!
 
 Happy coding!!
 
-## Makefile
-For convenience a [makefile](https://en.wikipedia.org/wiki/Make_(software)) is included with this project
+# Makefile
+
+For convenience a [makefile](<https://en.wikipedia.org/wiki/Make_(software)>) is included with this project
 to streamline a number of repetitive tasks. A helpful explanation and tutorial
 of Make is available [here](https://makefiletutorial.com).
 
@@ -68,23 +119,27 @@ where `target` is any target specified in the makefile.
 
 Assuming you have make installed, you can run any of the targets listed below.
 
-| **Target** |                                            **Description**                                           |
-|:----------:|:----------------------------------------------------------------------------------------------------:|
+| **Target** |                                           **Description**                                            |
+| :--------: | :--------------------------------------------------------------------------------------------------: |
 |    init    | Spin up the development environment. This is the default target if one is not provided (e.g. `make`) |
-|    build   | Build application docker image                                                                       |
-|     up     | Bring up the application docker compose stack (start the app)                                        |
-|    down    | Bring down the application docker compose stop (stop the app)                                        |
-|    reset   | Stop the app and remove volumes. Effectively start from scratch                                      |
-|   migrate  | Synchronize change made to models with the schema in the database                                    |
+|   build    |                                    Build application docker image                                    |
+|     up     |                    Bring up the application docker compose stack (start the app)                     |
+|    down    |                    Bring down the application docker compose stop (stop the app)                     |
+|   reset    |           Stop the app and remove volumes. Effectively start from scratch on the next `up`           |
+|  migrate   |                  Synchronize change made to models with the schema in the database                   |
+|   local    |                                     Install project requirements                                     |
 
 _Generated using [Markdown Tables Generator](https://www.tablesgenerator.com/markdown_tables#)_
 
-### Using makefile on Windows
+## Using makefile on Windows
+
 Windows does not support makefiles natively. However, if you have installed/enabled WSL,
 you can open a WSL terminal to use the makefile.
 
-## Deployment
+# Deployment
+
 TODO
 
 # Troubleshooting
+
 Common gotchas and resolution

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ volumes:
   # use named volume to persist data, in this case the database
   pgdata:
 
-    # share senstive info without exposing them via environment variables
 secrets:
+  # share senstive info without exposing them via environment variables
   secret_key:
     environment: SECRET_KEY
   postgres_user:
@@ -25,6 +25,7 @@ services:
       - POSTGRES_DB_FILE=/run/secrets/postgres_db
       - POSTGRES_USER_FILE=/run/secrets/postgres_user
       - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_passwd
+      - TZ=${GLOBAL_TIMEZONE:-America/New_York}
     secrets:
       - postgres_db
       - postgres_user
@@ -32,7 +33,9 @@ services:
   django:
     working_dir: /app
     volumes:
-      - .:/app
+      # The defaults value . is added so that the docker-compose.yaml file can
+      # work when running docker-outside-of-docker in devcontainer
+      - ${LOCAL_WORKSPACE_FOLDER:-.}:/app
     image: aau-vms
     secrets:
       - secret_key
@@ -40,7 +43,7 @@ services:
       - postgres_user
       - postgres_passwd
     environment:
-      - TZ=${GLOBAL_TIMEZONE:-America/New_York}}
+      - TZ=${GLOBAL_TIMEZONE:-America/New_York}
     ports:
       - ${DJANGO_PORT:-80}:8000
-    entrypoint: [ "python", "manage.py", "runserver", "0.0.0.0:8000" ]
+    entrypoint: ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ DJANGO_CONTAINER := vms-django-1
 
 # Build the Docker image
 build:
-	docker build --no-cache -t $(DOCKER_IMAGE_NAME) .
+	docker build -t $(DOCKER_IMAGE_NAME) .
 
 # Bring up the Docker Compose stack
 up:
@@ -23,6 +23,10 @@ reset:
 migrate:
 	docker exec $(DJANGO_CONTAINER) python manage.py makemigrations app
 	docker exec $(DJANGO_CONTAINER) python manage.py migrate
+
+# setup a local dev env - OS independent
+local:
+	pip install --user --requirement requirements.txt
 
 # Initialize: print welcome message, build image, and bring up the stack
 .PHONY: init


### PR DESCRIPTION
This change adds [dev containers](https://containers.dev) to simplify and streamline developers. This includes all the tools and dependencies and provides a standardized environment. With this, you can work on the codebase without having to install anything other than docker & git.

Additionally, this add [pre-commit hooks](https://pre-commit.com/#advanced) to perform linting and formatting checks prior to committing.