### PR TITLE
Update dev container to work better on Windows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,8 +40,8 @@
 			"settings": {
 				"editor.formatOnSave": true,
 				"debugpy.showPythonInlineValues": true,
-				"editor.formatOnSaveMode": "modificationsIfAvailable",
-				"editor.defaultFormatter": "bysabi.prettier-vscode-standard",
+				"editor.formatOnSaveMode": "file",
+				// "editor.defaultFormatter": "bysabi.prettier-vscode-standard",
 				"[jsonc]": {
 					"editor.defaultFormatter": "vscode.json-language-features"
 				},
@@ -51,8 +51,7 @@
 					"analysis.inlayHints.callArgumentNames": "partial",
 					"editor.defaultFormatter": "ms-python.black-formatter",
 					"editor.codeActionsOnSave": {
-						"source.organizeImports": "always",
-						"source.unusedImports": "always"
+						"source.organizeImports": "always"
 					}
 				},
 				"[shellscript]": {
@@ -70,9 +69,9 @@
 		}
 	},
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "chmod +x ./.devcontainer/postCreateCommand.sh && ./.devcontainer/postCreateCommand.sh"
+	"postCreateCommand": "chmod +x ./.devcontainer/postCreateCommand.sh && ./.devcontainer/postCreateCommand.sh",
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	"remoteUser": "root"
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -12,7 +12,7 @@ if [ ! -f "$INITIALIZATION_FILE" ]; then
     make init
 
     # install pre-commit hooks
-    pre-commit install
+    # pre-commit install
 
     # setup node modules
     cd react-admin && npm install && cd ..

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 ### ignore folder - helpful for files you don't want to delete or add to ignore file###
 IGNORE/
+react-admin/.vite/deps_temp_*/
 
 database-client-config.json
 *.pdk
@@ -200,7 +201,6 @@ cython_debug/
 
 # Icon must end with two \r
 Icon
-
 
 # Thumbnails
 ._*


### PR DESCRIPTION
Working with @tstoyano & @rstoyano we found a number of issues running the dev container on Windows.

This, along with @rstoyano's fix in PR #28 fixes them.

Specifically, this request includes:

- removing default formatter.
- automatic removal of unused imports. This made editing certain files (e.g. `models/__init__.py`) impossible
- remove pre-commit hooks. GitHub desktop GUI doesn't support pre-commit hooks
- @rstoyano fix